### PR TITLE
Working editing and deletion of posts

### DIFF
--- a/server/routing.py
+++ b/server/routing.py
@@ -4,4 +4,5 @@ import slack.consumers
 channel_routing = [
     route('background-slack-event', slack.consumers.event),
     route('background-slack-update', slack.consumers.update),
+    route('background-slack-action', slack.consumers.action),
 ]

--- a/server/routing.py
+++ b/server/routing.py
@@ -3,4 +3,5 @@ import slack.consumers
 
 channel_routing = [
     route('background-slack-event', slack.consumers.event),
+    route('background-slack-update', slack.consumers.update),
 ]

--- a/slack/__init__.py
+++ b/slack/__init__.py
@@ -1,4 +1,4 @@
-import os
+import os, re
 
 def error_msg(msg):
     return {
@@ -10,3 +10,23 @@ def error_msg(msg):
 def verified_token(token):
     app_verification_token = os.environ.get('SLACK_VERIFICATION_TOKEN')
     return app_verification_token == token or not app_verification_token
+
+def clear_tags(slack, text):
+    members = slack.users.list().body['members']
+    mem_map = [('<@{}>'.format(m['id']), '@{}'.format(m['name'])) for m in members]
+
+    channels = slack.channels.list().body['channels']
+    ch_map = [('<#{}|{}>'.format(c['id'], c['name']), '#{}'.format(c['name'])) for c in channels]
+
+    for k,v in mem_map + ch_map:
+        text = text.replace(k,v)
+    return text
+
+def revert_hyperlinks(text):
+    sa_items = re.findall(r'<([^!#]{1}.*?)>', event['message'].get('text', ''))
+    sa_re = [("<{}>".format(x), x) for x in sa_items]
+
+    for k,v in sa_re:
+        text = text.replace(k,v)
+
+    return text

--- a/slack/__init__.py
+++ b/slack/__init__.py
@@ -23,7 +23,7 @@ def clear_tags(slack, text):
     return text
 
 def revert_hyperlinks(text):
-    sa_items = re.findall(r'<([^!#]{1}.*?)>', event['message'].get('text', ''))
+    sa_items = re.findall(r'<([^!#]{1}.*?)>', text)
     sa_re = [("<{}>".format(x), x) for x in sa_items]
 
     for k,v in sa_re:

--- a/slack/consumers.py
+++ b/slack/consumers.py
@@ -61,23 +61,24 @@ def update(message):
 
     payload = message.content['payload']
     event = payload['event']
-    user = payload['user']
+    user = message.content['user']
 
-    local_team = get_object_or_404(Team, team_id=payload['team_id'])
-    local_team_interface = Slacker(local_team.app_access_token)
+    team = get_object_or_404(Team, team_id=message.content['team_id'])
+    team_interface = Slacker(team.app_access_token)
 
     if event.get('subtype') == "message_changed":
+        # team_interface.chat.udpate()
         pass
     elif event.get('subtype') == "message_deleted":
+        # team_interface.chat.delete()
         pass
     else:
         if event.get('subtype') in ["channel_join", "channel_leave"]:
             event['text'] = '_{}_'.format(event['text'])
 
-        slack = Slacker(local_team.app_access_token)
-        slack.chat.post_message(text=event['text'],
+        team_interface.chat.post_message(text=event['text'],
                                 attachments=event.get('attachments'),
-                                channel=payload['channel_id'],
+                                channel=message.content['channel_id'],
                                 username=(user['profile']['real_name'] or user['profile']['name']),
                                 icon_url=user['profile']['image_192'],
                                 as_user=False

--- a/slack/consumers.py
+++ b/slack/consumers.py
@@ -80,7 +80,7 @@ def update(message):
         msgs = team_interface.channels.history(message.content['channel_id'],
                                                count=100).body['messages']
 
-        sa_text = revert_hyperlinks(text)
+        sa_text = revert_hyperlinks(event['message'].get('text', ''))
 
         for msg in msgs:
             logger.debug(msg.get('text'))


### PR DESCRIPTION
Editing and deletion of posts now works. This was an issue primarily caused by Slack parsing mechanism doing an update to unfurl links instead of just posting the original message. This is probably to increase the speed that messages end up going out, but the update after the fact is rather annoying. 

closes #3 