### PR TITLE
Heroku stack control

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Application that allows you to create a bridge between two Slack teams, allowing
 ## Local Development
 
 Requirements:
-- Python 3.5
-- Latest version of pip for Python 3.5
+- Python 3.6
+- Latest version of pip for Python 3.6
 - virtualenv
 - Heroku CLI
 - Redis

--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/trianglefraternitymtu/slack-bridge",
   "website": "https://github.com/trianglefraternitymtu/slack-bridge",
   "keywords": ["django", "channels", "websockets", "slack"],
+  "stack": "heroku-16"
   "scripts": {
       "postdeploy": "python manage.py migrate"
   },


### PR DESCRIPTION
It would appear that Heroku updated their default stack, which breaks a number of packages. This would probably be because of how they installed something else in the image.